### PR TITLE
Fix folder node render when there isn't children

### DIFF
--- a/demo/app.component.ts
+++ b/demo/app.component.ts
@@ -145,6 +145,7 @@ export class AppComponent implements OnInit {
       cssClasses: {
         expanded: 'fa fa-caret-down',
         collapsed: 'fa fa-caret-right',
+        empty: 'fa fa-caret-right disabled',
         leaf: 'fa'
       },
       templates: {

--- a/demo/app.component.ts
+++ b/demo/app.component.ts
@@ -73,6 +73,13 @@ declare const alertify: any;
       font-size: 1.2em;
       font-style: italic;
     }
+    :host /deep/ .fa {
+      cursor: pointer;
+    }
+    :host /deep/ .fa.disabled {
+      cursor: inherit;
+      color: #757575;
+    }
   `]
 })
 export class AppComponent implements OnInit {
@@ -273,7 +280,21 @@ export class AppComponent implements OnInit {
               {value: 'Downloads', id: 49, children: []},
               {value: 'Desktop', id: 50, children: []},
               {value: 'Pictures', id: 51, children: []},
-              {value: 'Music', id: 52, children: []},
+              {
+                value: 'Music',
+                id: 52,
+                children: [{value: 'won\'t be displayed'}],
+                loadChildren: (callback) => {
+                  setTimeout(() => {
+                    callback([
+                      {value: '2Cellos', id: 78, children: []},
+                      {value: 'Michael Jackson', id: 79, children: []},
+                      {value: 'AC/DC', id: 80, children: []},
+                      {value: 'Adel', id: 81, children: []}
+                    ]);
+                  }, 5000);
+                }
+              },
               {value: 'Public', id: 53, children: []}
             ]
           },

--- a/src/styles.css
+++ b/src/styles.css
@@ -144,6 +144,17 @@ tree-internal .tree .folding.node-expanded:before {
   color: #757575;
 }
 
+tree-internal .tree .folding.node-empty {
+  color: #212121;
+  text-align: center;
+  font-size: 0.89em;
+}
+
+tree-internal .tree .folding.node-empty:before {
+  content: '\25B6';
+  color: #757575;
+}
+
 tree-internal .tree .folding.node-leaf {
   color: #212121;
   text-align: center;

--- a/src/tree.service.ts
+++ b/src/tree.service.ts
@@ -53,13 +53,9 @@ export class TreeService {
   }
 
   public fireNodeSwitchFoldingType(tree: Tree): void {
-    if (tree.isLeaf()) {
-      return;
-    }
-
     if (tree.isNodeExpanded()) {
       this.fireNodeExpanded(tree);
-    } else {
+    } else if (tree.isNodeCollapsed()) {
       this.fireNodeCollapsed(tree);
     }
   }

--- a/src/tree.types.ts
+++ b/src/tree.types.ts
@@ -3,6 +3,7 @@ import * as _ from 'lodash';
 export class FoldingType {
   public static Expanded: FoldingType = new FoldingType('node-expanded');
   public static Collapsed: FoldingType = new FoldingType('node-collapsed');
+  public static Empty: FoldingType = new FoldingType('node-empty');
   public static Leaf: FoldingType = new FoldingType('node-leaf');
 
   public constructor(private _cssClass: string) {
@@ -31,6 +32,9 @@ export interface CssClasses {
 
   /* The class or classes that should be added to the collapsed node */
   collapsed?: string;
+
+  /* The class or classes that should be added to the empty node */
+  empty?: string;
 
   /* The class or classes that should be added to the expanded to the leaf */
   leaf?: string;

--- a/test/data-provider/tree.data-provider.ts
+++ b/test/data-provider/tree.data-provider.ts
@@ -17,28 +17,33 @@ export class TreeDataProvider {
     },
     'first expanded property of cssClasses has higher priority': {
       treeModelA: { value: "12", settings: { cssClasses: { expanded: 'arrow-down-o' } } },
-      treeModelB: { value: "42", settings: { cssClasses: { expanded: 'arrow-down', collapsed: 'arrow-right', leaf: 'dot' } } },
-      result: { static: false, leftMenu: false, rightMenu: true, cssClasses: { expanded: 'arrow-down-o', collapsed: 'arrow-right', leaf: 'dot' } }
+      treeModelB: { value: "42", settings: { cssClasses: { expanded: 'arrow-down', collapsed: 'arrow-right', empty: 'arrow-gray', leaf: 'dot' } } },
+      result: { static: false, leftMenu: false, rightMenu: true, cssClasses: { expanded: 'arrow-down-o', collapsed: 'arrow-right', empty: 'arrow-gray', leaf: 'dot' } }
     },
     'first collapsed property of cssClasses has higher priority': {
       treeModelA: { value: "12", settings: { cssClasses: { collapsed: 'arrow-right-o' } } },
-      treeModelB: { value: "42", settings: { cssClasses: { expanded: 'arrow-down', collapsed: 'arrow-right', leaf: 'dot' } } },
-      result: { static: false, leftMenu: false, rightMenu: true, cssClasses: { expanded: 'arrow-down', collapsed: 'arrow-right-o', leaf: 'dot' } }
+      treeModelB: { value: "42", settings: { cssClasses: { expanded: 'arrow-down', collapsed: 'arrow-right', empty: 'arrow-gray', leaf: 'dot' } } },
+      result: { static: false, leftMenu: false, rightMenu: true, cssClasses: { expanded: 'arrow-down', collapsed: 'arrow-right-o', empty: 'arrow-gray', leaf: 'dot' } }
+    },
+    'first empty property of cssClasses has higher priority': {
+      treeModelA: { value: "12", settings: { cssClasses: { empty: 'arrow-gray-o' } } },
+      treeModelB: { value: "42", settings: { cssClasses: { expanded: 'arrow-down', collapsed: 'arrow-right', empty: 'arrow-gray', leaf: 'dot' } } },
+      result: { static: false, leftMenu: false, rightMenu: true, cssClasses: { expanded: 'arrow-down', collapsed: 'arrow-right', empty: 'arrow-gray-o', leaf: 'dot' } }
     },
     'first leaf property of cssClasses has higher priority': {
       treeModelA: { value: "12", settings: { cssClasses: { leaf: 'dot-o' } } },
-      treeModelB: { value: "42", settings: { cssClasses: { expanded: 'arrow-down', collapsed: 'arrow-right', leaf: 'dot' } } },
-      result: { static: false, leftMenu: false, rightMenu: true, cssClasses: { expanded: 'arrow-down', collapsed: 'arrow-right', leaf: 'dot-o' } }
+      treeModelB: { value: "42", settings: { cssClasses: { expanded: 'arrow-down', collapsed: 'arrow-right', empty: 'arrow-gray', leaf: 'dot' } } },
+      result: { static: false, leftMenu: false, rightMenu: true, cssClasses: { expanded: 'arrow-down', collapsed: 'arrow-right', empty: 'arrow-gray', leaf: 'dot-o' } }
     },
     'first properties of cssClasses has higher priority': {
-      treeModelA: { value: "12", settings: { cssClasses: { expanded: 'arrow-down-o', collapsed: 'arrow-right-o', leaf: 'dot-o' } } },
-      treeModelB: { value: "42", settings: { cssClasses: { expanded: 'arrow-down', collapsed: 'arrow-right', leaf: 'dot' } } },
-      result: { static: false, leftMenu: false, rightMenu: true, cssClasses: { expanded: 'arrow-down-o', collapsed: 'arrow-right-o', leaf: 'dot-o' } }
+      treeModelA: { value: "12", settings: { cssClasses: { expanded: 'arrow-down-o', collapsed: 'arrow-right-o', empty: 'arrow-gray-o', leaf: 'dot-o' } } },
+      treeModelB: { value: "42", settings: { cssClasses: { expanded: 'arrow-down', collapsed: 'arrow-right', empty: 'arrow-gray', leaf: 'dot' } } },
+      result: { static: false, leftMenu: false, rightMenu: true, cssClasses: { expanded: 'arrow-down-o', collapsed: 'arrow-right-o', empty: 'arrow-gray-o', leaf: 'dot-o' } }
     },
     'second properties of cssClasses in settings has priority, if first source doesn\'t have them': {
       treeModelA: { value: '42', settings: { static: true, leftMenu: true, rightMenu: false } },
-      treeModelB: { value: '12', settings: { cssClasses: { expanded: 'arrow-down-o', collapsed: 'arrow-right-o', leaf: 'dot-o' } } },
-      result: { static: true, leftMenu: true, rightMenu: false, cssClasses: { expanded: 'arrow-down-o', collapsed: 'arrow-right-o', leaf: 'dot-o' } }
+      treeModelB: { value: '12', settings: { cssClasses: { expanded: 'arrow-down-o', collapsed: 'arrow-right-o', empty: 'arrow-gray-o', leaf: 'dot-o' } } },
+      result: { static: true, leftMenu: true, rightMenu: false, cssClasses: { expanded: 'arrow-down-o', collapsed: 'arrow-right-o', empty: 'arrow-gray-o', leaf: 'dot-o' } }
     },
     'first node property of templates has higher priority': {
       treeModelA: { value: "12", settings: { templates: { node: '<i class="folder-o"></i>' } } },

--- a/test/tree.service.spec.ts
+++ b/test/tree.service.spec.ts
@@ -189,6 +189,21 @@ describe('TreeService', () => {
     expect(treeService.nodeCollapsed$.next).not.toHaveBeenCalled();
   });
 
+  it('does not fire "expanded", "collapsed" events for a empty node', () => {
+    const masterTree = new Tree({
+      value: 'Master',
+      children: []
+    });
+
+    spyOn(treeService.nodeExpanded$, 'next');
+    spyOn(treeService.nodeCollapsed$, 'next');
+
+    treeService.fireNodeSwitchFoldingType(masterTree);
+
+    expect(treeService.nodeExpanded$.next).not.toHaveBeenCalled();
+    expect(treeService.nodeCollapsed$.next).not.toHaveBeenCalled();
+  });
+
   it('fires "expanded" event for expanded tree', () => {
     const masterTree = new Tree({
       value: 'Master',

--- a/test/tree.spec.ts
+++ b/test/tree.spec.ts
@@ -336,6 +336,70 @@ describe('Tree', () => {
     expect(child.positionInParent).toEqual(2);
   });
 
+  it('cannot create child node when children are loaded async', () => {
+    const servantTree = new Tree({
+      value: 'Master',
+      loadChildren: (callback: Function) => {
+        setTimeout(() => {
+          callback([
+            { value: 'Servant#1' },
+            { value: 'Servant#2' }
+          ]);
+        }, 10);
+      }
+    });
+
+    const child = servantTree.createNode(false);
+
+    expect(child).toEqual(null);
+    expect(servantTree.hasChild(child)).toEqual(false);
+  });
+
+  it('can create tree without any children', () => {
+    const master = new Tree({
+      value: 'Master',
+      children: []
+    });
+
+    expect(master.isRoot()).toEqual(true);
+    expect(master.isBranch()).toEqual(true);
+    expect(master.children).toEqual([]);
+    expect(master.isLeaf()).toEqual(false);
+    expect(master.isNodeExpanded()).toEqual(false);
+    expect(master.isNodeCollapsed()).toEqual(false);
+    expect(master.foldingType).toEqual(FoldingType.Empty);
+  });
+
+  it('creating a child to a collapsed node, will expand it', () => {
+    const servantTree = new Tree({
+      value: 'Master',
+      children: [
+        { value: 'Servant#1' },
+        { value: 'Servant#2' }
+      ]
+    });
+
+    expect(servantTree.isNodeExpanded()).toEqual(true);
+    expect(servantTree.isNodeCollapsed()).toEqual(false);
+
+    servantTree.switchFoldingType();
+
+    expect(servantTree.isNodeExpanded()).toEqual(false);
+    expect(servantTree.isNodeCollapsed()).toEqual(true);
+
+    const child = servantTree.createNode(true);
+
+    expect(servantTree.isNodeExpanded()).toEqual(true);
+    expect(servantTree.isNodeCollapsed()).toEqual(false);
+
+    expect(servantTree.hasChild(child)).toEqual(true);
+    expect(child.value).toEqual('');
+    expect(child.children).toEqual([]);
+    expect(child.isLeaf()).toEqual(false);
+    expect(child.isNew()).toEqual(true);
+    expect(child.positionInParent).toEqual(2);
+  });
+
   it('creates sibling node (leaf)', () => {
     const servantTree = new Tree({
       value: 'Master',
@@ -488,6 +552,17 @@ describe('Tree', () => {
     expect(servantNumber2Tree.hasSibling(servantNumber1Tree)).toEqual(true);
   });
 
+  it('knows its not leaf', () => {
+    const masterTree = new Tree({
+      value: 'Master',
+      children: []
+    });
+
+    expect(masterTree.isRoot()).toEqual(true);
+    expect(masterTree.isLeaf()).toEqual(false);
+    expect(masterTree.hasChildren()).toEqual(false);
+  });
+
   it('knows its children', () => {
     const masterTree = new Tree({
       value: 'Master',
@@ -623,6 +698,7 @@ describe('Tree', () => {
 
     expect(masterTree.isLeaf()).toEqual(true);
     expect(masterTree.isNodeExpanded()).toEqual(false);
+    expect(masterTree.isNodeCollapsed()).toEqual(false);
     expect(masterTree.foldingType).toEqual(FoldingType.Leaf);
   });
 
@@ -638,6 +714,31 @@ describe('Tree', () => {
     expect(masterTree.foldingType).toEqual(FoldingType.Leaf);
   });
 
+  it('has "Empty" folding type if it is branch and has no children', () => {
+    const masterTree = new Tree({
+      value: 'Master',
+      children: []
+    });
+
+    expect(masterTree.isBranch()).toEqual(true);
+    expect(masterTree.isNodeExpanded()).toEqual(false);
+    expect(masterTree.isNodeCollapsed()).toEqual(false);
+    expect(masterTree.foldingType).toEqual(FoldingType.Empty);
+  });
+
+  it('cannot switch "Empty" folding type', () => {
+    const masterTree = new Tree({
+      value: 'Master',
+       children: []
+    });
+
+    expect(masterTree.foldingType).toEqual(FoldingType.Empty);
+
+    masterTree.switchFoldingType();
+
+    expect(masterTree.foldingType).toEqual(FoldingType.Empty);
+  });
+
   it('has "Expanded" folding type if it is branch and expanded (by default for branches)', () => {
     const masterTree = new Tree({
       value: 'Master',
@@ -649,6 +750,7 @@ describe('Tree', () => {
 
     expect(masterTree.isBranch()).toEqual(true);
     expect(masterTree.isNodeExpanded()).toEqual(true);
+    expect(masterTree.isNodeCollapsed()).toEqual(false);
     expect(masterTree.foldingType).toEqual(FoldingType.Expanded);
   });
 
@@ -663,16 +765,19 @@ describe('Tree', () => {
 
     expect(masterTree.foldingType).toEqual(FoldingType.Expanded);
     expect(masterTree.isNodeExpanded()).toEqual(true);
+    expect(masterTree.isNodeCollapsed()).toEqual(false);
 
     masterTree.switchFoldingType();
 
     expect(masterTree.foldingType).toEqual(FoldingType.Collapsed);
     expect(masterTree.isNodeExpanded()).toEqual(false);
+    expect(masterTree.isNodeCollapsed()).toEqual(true);
 
     masterTree.switchFoldingType();
 
     expect(masterTree.foldingType).toEqual(FoldingType.Expanded);
     expect(masterTree.isNodeExpanded()).toEqual(true);
+    expect(masterTree.isNodeCollapsed()).toEqual(false);
   });
 
   it('has undefined status by default', () => {
@@ -724,6 +829,34 @@ describe('Tree', () => {
       expect(tree.children.length).toEqual(2);
       expect(tree.children[0].value).toEqual(children[0].value);
       expect(tree.children[1].value).toEqual(children[1].value);
+      done();
+    });
+  });
+
+  it('has right statuses while loading its children asynchronously', (done: Function) => {
+    const tree = new Tree({
+      value: 'AsyncParent',
+      loadChildren: (callback: Function) => {
+        setTimeout(() => {
+          callback([
+            { value: 'Child#1' },
+            { value: 'Child#2' }
+          ]);
+        }, 200);
+      }
+    });
+
+    tree.switchFoldingType();
+    expect(tree.childrenWereLoaded()).toEqual(false);
+    setTimeout(() => {
+      expect(tree.childrenAreBeingLoaded()).toEqual(true);
+    }, 110);
+    tree.childrenAsync.subscribe((children: Tree[]) => {
+      expect(tree.children.length).toEqual(2);
+      expect(tree.children[0].value).toEqual(children[0].value);
+      expect(tree.children[1].value).toEqual(children[1].value);
+      expect(tree.childrenWereLoaded()).toEqual(true);
+      expect(tree.childrenAreBeingLoaded()).toEqual(false);
       done();
     });
   });
@@ -829,6 +962,28 @@ describe('Tree', () => {
 
     expect(masterTree.isNodeExpanded()).toEqual(false, 'node is collapsed');
     expect(masterTree.foldingCssClass).toEqual('fa fa-caret-right');
+  });
+
+  it('can add a css classes for empty nodes', () => {
+    const masterTree = new Tree({
+      value: 'Master',
+      settings: {
+        cssClasses: {
+          empty: 'fa fa-caret-left'
+        }
+      },
+      children: []
+    });
+
+    expect(masterTree.isNodeExpanded()).toEqual(false, 'initially node is not expanded');
+    expect(masterTree.isNodeCollapsed()).toEqual(false, 'initially node is not collapsed');
+    expect(masterTree.foldingCssClass).toEqual('fa fa-caret-left');
+
+    masterTree.switchFoldingType();
+
+    expect(masterTree.isNodeExpanded()).toEqual(false, 'node cannot collapsed');
+    expect(masterTree.isNodeCollapsed()).toEqual(false, 'node cannot expand');
+    expect(masterTree.foldingCssClass).toEqual('fa fa-caret-left');
   });
 
   it('can add a css classes for leaf nodes', () => {

--- a/test/tree.types.spec.ts
+++ b/test/tree.types.spec.ts
@@ -17,6 +17,7 @@ describe('FoldingType', () => {
   it('should have correct cssClass per folding type', () => {
     expect(FoldingType.Expanded.cssClass).toEqual('node-expanded');
     expect(FoldingType.Collapsed.cssClass).toEqual('node-collapsed');
+    expect(FoldingType.Empty.cssClass).toEqual('node-empty');
     expect(FoldingType.Leaf.cssClass).toEqual('node-leaf');
   });
 });


### PR DESCRIPTION
Fixed #87 

Added new folding type for empty nodes, because there is nothing to collapse or expand.
Reset folding type on create or remove of a child on a node.
