### PR TITLE
lastIndex for NodeRemovedEvent

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -13,6 +13,7 @@
   background-color: #eee;
   color: #212121;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  z-index: 999;
 }
 
 .node-menu .node-menu-content li.node-menu-item {

--- a/src/tree.events.ts
+++ b/src/tree.events.ts
@@ -25,7 +25,7 @@ export class NodeMovedEvent extends NodeDestructiveEvent {
 }
 
 export class NodeRemovedEvent extends NodeDestructiveEvent {
-  public constructor(node: Tree) {
+  public constructor(node: Tree, public lastIndex: number) {
     super(node);
   }
 }

--- a/src/tree.service.ts
+++ b/src/tree.service.ts
@@ -33,7 +33,7 @@ export class TreeService {
   }
 
   public fireNodeRemoved(tree: Tree): void {
-    this.nodeRemoved$.next(new NodeRemovedEvent(tree));
+    this.nodeRemoved$.next(new NodeRemovedEvent(tree, tree.positionInParent));
   }
 
   public fireNodeCreated(tree: Tree): void {

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -262,7 +262,7 @@ export class Tree {
    * @returns {number} The position inside a parent.
    */
   public get positionInParent(): number {
-    return this.parent.children ? this.parent.children.indexOf(this) : -1;
+    return this.parent ? (this.parent.children ? this.parent.children.indexOf(this) : -1) : -1;
   }
 
   /**

--- a/test/tree.service.spec.ts
+++ b/test/tree.service.spec.ts
@@ -47,7 +47,19 @@ describe('TreeService', () => {
     treeService.fireNodeRemoved(tree);
 
     expect(treeService.nodeRemoved$.next).toHaveBeenCalledTimes(1);
-    expect(treeService.nodeRemoved$.next).toHaveBeenCalledWith(new NodeRemovedEvent(tree));
+    expect(treeService.nodeRemoved$.next).toHaveBeenCalledWith(new NodeRemovedEvent(tree, - 1));
+  });
+
+  // TODO: add test for lastIndex of removed node
+
+  it('fires node removed events', () => {
+    spyOn(treeService.nodeRemoved$, 'next');
+
+    const tree = new Tree({value: 'Master'});
+    treeService.fireNodeRemoved(tree);
+
+    expect(treeService.nodeRemoved$.next).toHaveBeenCalledTimes(1);
+    expect(treeService.nodeRemoved$.next).toHaveBeenCalledWith(new NodeRemovedEvent(tree, - 1));
   });
 
   it('fires node moved events', () => {


### PR DESCRIPTION
- added z-index of 999 to prevent right click menu from being coveredd by other elements
- implemented lastIndex as second parameter of NodeRemovedEvent (#111)
- fixed null pointer in positionInParent() for top level node
