### PR TITLE
Support ngrx - Loading children using external libraries (Redux, ect`)

### DIFF
--- a/src/tree.component.ts
+++ b/src/tree.component.ts
@@ -46,6 +46,9 @@ export class TreeComponent implements OnInit, OnChanges, OnDestroy {
   @Output()
   public nodeCollapsed: EventEmitter<any> = new EventEmitter();
 
+@Output()
+public loadNextLevel: EventEmitter<any> = new EventEmitter();
+
   public tree: Tree;
   @ViewChild('rootComponent') public rootComponent;
 
@@ -89,6 +92,10 @@ export class TreeComponent implements OnInit, OnChanges, OnDestroy {
 
     this.subscriptions.push(this.treeService.nodeCollapsed$.subscribe((e: NodeEvent) => {
       this.nodeCollapsed.emit(e);
+    }));
+
+    this.subscriptions.push(this.treeService.loadNextLevel$.subscribe((e: NodeEvent) => {
+      this.loadNextLevel.emit(e);
     }));
   }
 

--- a/src/tree.events.ts
+++ b/src/tree.events.ts
@@ -54,3 +54,9 @@ export class NodeCollapsedEvent extends NodeEvent {
     super(node);
   }
 }
+
+export class LoadNextLevelEvent extends NodeEvent {
+  public constructor(node: Tree) {
+    super(node);
+  }
+}

--- a/src/tree.service.ts
+++ b/src/tree.service.ts
@@ -113,10 +113,10 @@ export class TreeService {
     const result = tree.node.hasChildren &&
       !tree.node.loadChildren &&
       !tree.childrenAreBeingLoaded() &&
-      (!tree.children || tree.children === [])
+      (!tree.children || tree.children === []);
 
-      if(result) {
-        tree.loadingChildrenRequested
+      if (result) {
+        tree.loadingChildrenRequested();
       }
 
       return result;

--- a/src/tree.service.ts
+++ b/src/tree.service.ts
@@ -15,6 +15,7 @@ import { Observable, Subject } from 'rxjs/Rx';
 import { ElementRef, Inject, Injectable } from '@angular/core';
 import { NodeDraggableService } from './draggable/node-draggable.service';
 import { NodeDraggableEvent } from './draggable/draggable.events';
+import {isEmpty} from './utils/fn.utils'
 
 @Injectable()
 export class TreeService {
@@ -110,15 +111,15 @@ export class TreeService {
 
   private shouldFireLoadNextLevel(tree: Tree): boolean {
 
-    const result = tree.node.hasChildren &&
+    const shouldLoadNextLevel = tree.node.emitLoadNextLevel &&
       !tree.node.loadChildren &&
       !tree.childrenAreBeingLoaded() &&
-      (!tree.children || tree.children === []);
+      (!tree.children ||isEmpty(tree.children));
 
-      if (result) {
+      if (shouldLoadNextLevel) {
         tree.loadingChildrenRequested();
       }
 
-      return result;
+      return shouldLoadNextLevel;
   }
 }

--- a/src/tree.service.ts
+++ b/src/tree.service.ts
@@ -15,7 +15,7 @@ import { Observable, Subject } from 'rxjs/Rx';
 import { ElementRef, Inject, Injectable } from '@angular/core';
 import { NodeDraggableService } from './draggable/node-draggable.service';
 import { NodeDraggableEvent } from './draggable/draggable.events';
-import {isEmpty} from './utils/fn.utils'
+import {isEmpty} from './utils/fn.utils';
 
 @Injectable()
 export class TreeService {
@@ -114,7 +114,7 @@ export class TreeService {
     const shouldLoadNextLevel = tree.node.emitLoadNextLevel &&
       !tree.node.loadChildren &&
       !tree.childrenAreBeingLoaded() &&
-      (!tree.children ||isEmpty(tree.children));
+      (!tree.children || isEmpty(tree.children));
 
       if (shouldLoadNextLevel) {
         tree.loadingChildrenRequested();

--- a/src/tree.service.ts
+++ b/src/tree.service.ts
@@ -5,7 +5,8 @@ import {
   NodeMovedEvent,
   NodeRemovedEvent,
   NodeRenamedEvent,
-  NodeSelectedEvent
+  NodeSelectedEvent,
+  LoadNextLevelEvent
 } from './tree.events';
 import { RenamableNode } from './tree.types';
 import { Tree } from './tree';
@@ -24,6 +25,7 @@ export class TreeService {
   public nodeSelected$: Subject<NodeSelectedEvent> = new Subject<NodeSelectedEvent>();
   public nodeExpanded$: Subject<NodeExpandedEvent> = new Subject<NodeExpandedEvent>();
   public nodeCollapsed$: Subject<NodeCollapsedEvent> = new Subject<NodeCollapsedEvent>();
+  public loadNextLevel$: Subject<LoadNextLevelEvent> = new Subject<LoadNextLevelEvent>();
 
   private controllers: Map<string | number, TreeController> = new Map();
 
@@ -58,6 +60,9 @@ export class TreeService {
   public fireNodeSwitchFoldingType(tree: Tree): void {
     if (tree.isNodeExpanded()) {
       this.fireNodeExpanded(tree);
+      if(tree.node.hasChildren && (!tree.children || tree.children === [])){
+        this.fireLoadNextLevel(tree);
+      }
     } else if (tree.isNodeCollapsed()) {
       this.fireNodeCollapsed(tree);
     }
@@ -69,6 +74,10 @@ export class TreeService {
 
   private fireNodeCollapsed(tree: Tree): void {
     this.nodeCollapsed$.next(new NodeCollapsedEvent(tree));
+  }
+
+  private fireLoadNextLevel(tree: Tree): void {
+    this.nodeCollapsed$.next(new LoadNextLevelEvent(tree));
   }
 
   public draggedStream(tree: Tree, element: ElementRef): Observable<NodeDraggableEvent> {

--- a/src/tree.service.ts
+++ b/src/tree.service.ts
@@ -29,7 +29,7 @@ export class TreeService {
 
   private controllers: Map<string | number, TreeController> = new Map();
 
-  public constructor(@Inject(NodeDraggableService) private nodeDraggableService: NodeDraggableService) {
+  public constructor( @Inject(NodeDraggableService) private nodeDraggableService: NodeDraggableService) {
     this.nodeRemoved$.subscribe((e: NodeRemovedEvent) => e.node.removeItselfFromParent());
   }
 
@@ -60,7 +60,7 @@ export class TreeService {
   public fireNodeSwitchFoldingType(tree: Tree): void {
     if (tree.isNodeExpanded()) {
       this.fireNodeExpanded(tree);
-      if(tree.node.hasChildren && (!tree.children || tree.children === [])){
+      if (this.shouldFireLoadNextLevel(tree)) {
         this.fireLoadNextLevel(tree);
       }
     } else if (tree.isNodeCollapsed()) {
@@ -77,7 +77,7 @@ export class TreeService {
   }
 
   private fireLoadNextLevel(tree: Tree): void {
-    this.nodeCollapsed$.next(new LoadNextLevelEvent(tree));
+    this.loadNextLevel$.next(new LoadNextLevelEvent(tree));
   }
 
   public draggedStream(tree: Tree, element: ElementRef): Observable<NodeDraggableEvent> {
@@ -106,5 +106,19 @@ export class TreeService {
 
   public hasController(id: string | number): boolean {
     return this.controllers.has(id);
+  }
+
+  private shouldFireLoadNextLevel(tree: Tree): boolean {
+
+    const result = tree.node.hasChildren &&
+      !tree.node.loadChildren &&
+      !tree.childrenAreBeingLoaded() &&
+      (!tree.children || tree.children === [])
+
+      if(result) {
+        tree.loadingChildrenRequested
+      }
+
+      return result;
   }
 }

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -87,10 +87,10 @@ export class Tree {
   }
 
   private buildTreeFromModel(model: TreeModel, parent: Tree, isBranch: boolean): void {
-     this.parent = parent;
+    this.parent = parent;
     this.node = Object.assign(omit(model, 'children') as TreeModel, {
       settings: TreeModelSettings.merge(model, get(parent, 'node') as TreeModel)
-    }, {hasChildren : model.hasChildren === true}) as TreeModel;
+    }, { hasChildren: model.hasChildren === true }) as TreeModel;
 
     if (isFunction(this.node.loadChildren)) {
       this._loadChildren = this.node.loadChildren;
@@ -139,7 +139,6 @@ export class Tree {
    * @returns {boolean} A flag indicating that children should be loaded for the current node.
    */
   public childrenShouldBeLoaded(): boolean {
-    console.log(`hasChildren ${this.node.hasChildren}`)
     return !!this._loadChildren || this.node.hasChildren === true;
   }
 

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -90,7 +90,7 @@ export class Tree {
     this.parent = parent;
     this.node = Object.assign(omit(model, 'children') as TreeModel, {
       settings: TreeModelSettings.merge(model, get(parent, 'node') as TreeModel)
-    }, { hasChildren: model.hasChildren === true }) as TreeModel;
+    }, { emitLoadNextLevel: model.emitLoadNextLevel === true }) as TreeModel;
 
     if (isFunction(this.node.loadChildren)) {
       this._loadChildren = this.node.loadChildren;
@@ -108,10 +108,10 @@ export class Tree {
   public hasDeferredChildren(): boolean {
     return typeof this._loadChildren === 'function';
   }
-/* Setting the children loading state to Loading since a request was dispatched to the client */
-public loadingChildrenRequested(): void {
-this._childrenLoadingState = ChildrenLoadingState.Loading;
-}
+  /* Setting the children loading state to Loading since a request was dispatched to the client */
+  public loadingChildrenRequested(): void {
+    this._childrenLoadingState = ChildrenLoadingState.Loading;
+  }
 
   /**
    * Check whether children of the node are being loaded.
@@ -143,7 +143,7 @@ this._childrenLoadingState = ChildrenLoadingState.Loading;
    * @returns {boolean} A flag indicating that children should be loaded for the current node.
    */
   public childrenShouldBeLoaded(): boolean {
-    return !!this._loadChildren || this.node.hasChildren === true;
+    return !!this._loadChildren || this.node.emitLoadNextLevel === true;
   }
 
   /**
@@ -340,7 +340,7 @@ this._childrenLoadingState = ChildrenLoadingState.Loading;
    * @returns {boolean} A flag indicating whether or not this tree is a "Branch".
    */
   public isBranch(): boolean {
-    return this.node.hasChildren || Array.isArray(this._children);
+    return this.node.emitLoadNextLevel === true || Array.isArray(this._children);
   }
 
   /**
@@ -411,7 +411,7 @@ this._childrenLoadingState = ChildrenLoadingState.Loading;
    * If node is a "Branch" and it is expanded, then by invoking current method state of the tree should be switched to "collapsed" and vice versa.
    */
   public switchFoldingType(): void {
-    if ((this.isLeaf() || !this.hasChildren())) {
+    if (this.isLeaf() || !this.hasChildren()) {
       return;
     }
     this.node._foldingType = this.isNodeExpanded() ? FoldingType.Collapsed : FoldingType.Expanded;

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -24,7 +24,7 @@ export class Tree {
   private _children: Tree[];
   private _loadChildren: ChildrenLoadingFunction;
   private _childrenLoadingState: ChildrenLoadingState = ChildrenLoadingState.NotStarted;
-
+private _wasExpanded : boolean = false; //Let the user to try and expand the branch once to load the next level
   private _childrenAsyncOnce: () => Observable<Tree[]> = once(() => {
     return new Observable((observer: Observer<Tree[]>) => {
       setTimeout(() => {
@@ -408,11 +408,24 @@ export class Tree {
    * If node is a "Branch" and it is expanded, then by invoking current method state of the tree should be switched to "collapsed" and vice versa.
    */
   public switchFoldingType(): void {
-    if (this.isLeaf() || !this.hasChildren()) {
+//If we tried to load the children and no children were loaded the folding type should be collapsed
+if(this._wasExpanded && !this._children) {
+  this.node._foldingType = FoldingType.Collapsed;
+  return;
+}
+
+//If this is the first time the node is expanded try to expand it anyway
+    if ((this.isLeaf() || !this.hasChildren()) && this._wasExpanded) {
       return;
     }
 
-    this.node._foldingType = this.isNodeExpanded() ? FoldingType.Collapsed : FoldingType.Expanded;
+
+if(this.isNodeExpanded()) {
+  this.node._foldingType = FoldingType.Collapsed;
+}
+else
+    this.node._foldingType =  FoldingType.Expanded;
+this._wasExpanded = true; //Mark the node as expanded
   }
 
   /**

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -108,6 +108,10 @@ export class Tree {
   public hasDeferredChildren(): boolean {
     return typeof this._loadChildren === 'function';
   }
+/* Setting the children loading state to Loading since a request was dispatched to the client */
+public loadingChildrenRequested(): void {
+this._childrenLoadingState = ChildrenLoadingState.Loading;
+}
 
   /**
    * Check whether children of the node are being loaded.

--- a/src/tree.types.ts
+++ b/src/tree.types.ts
@@ -22,9 +22,10 @@ export interface TreeModel {
   children?: TreeModel[];
   loadChildren?: ChildrenLoadingFunction;
   settings?: TreeModelSettings;
+  hasChildren?: boolean;
   _status?: TreeStatus;
   _foldingType?: FoldingType;
-}
+  }
 
 export interface CssClasses {
   /* The class or classes that should be added to the expanded node */

--- a/src/tree.types.ts
+++ b/src/tree.types.ts
@@ -22,7 +22,7 @@ export interface TreeModel {
   children?: TreeModel[];
   loadChildren?: ChildrenLoadingFunction;
   settings?: TreeModelSettings;
-  hasChildren?: boolean;
+  emitLoadNextLevel?: boolean;
   _status?: TreeStatus;
   _foldingType?: FoldingType;
   }

--- a/test/tree.service.spec.ts
+++ b/test/tree.service.spec.ts
@@ -300,7 +300,7 @@ describe('TreeService', () => {
             { value: '3' }
           ]);
 
-        })
+        });
       }
     });
 

--- a/test/tree.service.spec.ts
+++ b/test/tree.service.spec.ts
@@ -255,4 +255,98 @@ describe('TreeService', () => {
     expect(treeService.nodeCollapsed$.next).toHaveBeenCalled();
     expect(treeService.nodeExpanded$.next).not.toHaveBeenCalled();
   });
+
+  it('fires "loadNextLevel" event when expanding node with hasChildren property set to true', () => {
+    const masterTree = new Tree({
+      value: 'Master',
+      hasChildren: true
+    });
+
+    masterTree.switchFoldingType();
+
+    spyOn(treeService.loadNextLevel$, 'next');
+
+    treeService.fireNodeSwitchFoldingType(masterTree);
+
+    expect(treeService.loadNextLevel$.next).toHaveBeenCalled();
+  });
+
+  it('fires "loadNextLevel" only once', () => {
+    const masterTree = new Tree({
+      value: 'Master',
+      hasChildren: true
+    });
+
+    masterTree.switchFoldingType();
+    masterTree.switchFoldingType();
+    masterTree.switchFoldingType();
+
+    spyOn(treeService.loadNextLevel$, 'next');
+
+    treeService.fireNodeSwitchFoldingType(masterTree);
+
+    expect(treeService.loadNextLevel$.next).toHaveBeenCalledTimes(1);
+  });
+
+  it('not fires "loadNextLevel" if "loadChildren" function is provided', () => {
+    const masterTree = new Tree({
+      value: 'Master',
+      hasChildren: true,
+      loadChildren: (callback) => {
+        setTimeout(() => {
+          callback([
+            { value: '1' },
+            { value: '2' },
+            { value: '3' }
+          ]);
+
+        })
+      }
+    });
+
+    masterTree.switchFoldingType();
+
+
+    spyOn(treeService.loadNextLevel$, 'next');
+
+    treeService.fireNodeSwitchFoldingType(masterTree);
+
+    expect(treeService.loadNextLevel$.next).not.toHaveBeenCalled();
+  });
+
+  it('not fires "loadNextLevel" if children are provided', () => {
+    const masterTree = new Tree({
+      value: 'Master',
+      hasChildren: true,
+      children: [
+        { value: '1' },
+        { value: '2' },
+        { value: '3' }
+      ]
+    });
+
+    masterTree.switchFoldingType();
+
+    spyOn(treeService.loadNextLevel$, 'next');
+
+    treeService.fireNodeSwitchFoldingType(masterTree);
+
+    expect(treeService.loadNextLevel$.next).not.toHaveBeenCalled();
+  });
+
+  it('not fires "loadNextLevel" event if "hasChildren" is false or does not exists', () => {
+    const masterTree = new Tree({
+      value: 'Master',
+    });
+
+    masterTree.switchFoldingType();
+
+    spyOn(treeService.loadNextLevel$, 'next');
+
+    treeService.fireNodeSwitchFoldingType(masterTree);
+
+    expect(treeService.loadNextLevel$.next).not.toHaveBeenCalled();
+  });
+
+
 });

--- a/test/tree.service.spec.ts
+++ b/test/tree.service.spec.ts
@@ -259,7 +259,7 @@ describe('TreeService', () => {
   it('fires "loadNextLevel" event when expanding node with hasChildren property set to true', () => {
     const masterTree = new Tree({
       value: 'Master',
-      hasChildren: true
+      emitLoadNextLevel: true
     });
 
     masterTree.switchFoldingType();
@@ -274,7 +274,7 @@ describe('TreeService', () => {
   it('fires "loadNextLevel" only once', () => {
     const masterTree = new Tree({
       value: 'Master',
-      hasChildren: true
+      emitLoadNextLevel: true
     });
 
     masterTree.switchFoldingType();
@@ -288,10 +288,26 @@ describe('TreeService', () => {
     expect(treeService.loadNextLevel$.next).toHaveBeenCalledTimes(1);
   });
 
+  it('fires "loadNextLevel" if children are provided as empty array', () => {
+    const masterTree = new Tree({
+      value: 'Master',
+      emitLoadNextLevel: true,
+      children: []
+    });
+
+    masterTree.switchFoldingType();
+
+    spyOn(treeService.loadNextLevel$, 'next');
+
+    treeService.fireNodeSwitchFoldingType(masterTree);
+
+    expect(treeService.loadNextLevel$.next).toHaveBeenCalled();
+  });
+
   it('not fires "loadNextLevel" if "loadChildren" function is provided', () => {
     const masterTree = new Tree({
       value: 'Master',
-      hasChildren: true,
+      emitLoadNextLevel: true,
       loadChildren: (callback) => {
         setTimeout(() => {
           callback([
@@ -317,7 +333,7 @@ describe('TreeService', () => {
   it('not fires "loadNextLevel" if children are provided', () => {
     const masterTree = new Tree({
       value: 'Master',
-      hasChildren: true,
+      emitLoadNextLevel: true,
       children: [
         { value: '1' },
         { value: '2' },

--- a/test/tree.spec.ts
+++ b/test/tree.spec.ts
@@ -1086,4 +1086,32 @@ describe('Tree', () => {
     expect(masterTree.children[1].leftMenuTemplate).toEqual('<i class="navigation"></i>');
   });
 
+  it('should load children when hasChildren is true', () => {
+
+    const model: TreeModel = {
+      value: 'root',
+      hasChildren: true,
+      id: 6,
+    }
+
+    const tree: Tree = new Tree(model);
+
+    expect(tree.hasChildren).toBeTruthy();
+    expect(tree.childrenShouldBeLoaded()).toBeTruthy();
+
+  });
+
+  it('should be considered as a branch if hasChildren is true', () => {
+
+    const model: TreeModel = {
+      value: 'root',
+      hasChildren: true,
+      id: 6,
+    }
+
+    const tree: Tree = new Tree(model);
+
+    expect(tree.isBranch()).toBeTruthy();
+  });
+
 });

--- a/test/tree.spec.ts
+++ b/test/tree.spec.ts
@@ -1090,7 +1090,7 @@ describe('Tree', () => {
 
     const model: TreeModel = {
       value: 'root',
-      hasChildren: true,
+      emitLoadNextLevel: true,
       id: 6,
     };
 
@@ -1105,7 +1105,7 @@ describe('Tree', () => {
 
     const model: TreeModel = {
       value: 'root',
-      hasChildren: true,
+      emitLoadNextLevel: true,
       id: 6,
     };
 

--- a/test/tree.spec.ts
+++ b/test/tree.spec.ts
@@ -1092,7 +1092,7 @@ describe('Tree', () => {
       value: 'root',
       hasChildren: true,
       id: 6,
-    }
+    };
 
     const tree: Tree = new Tree(model);
 
@@ -1107,7 +1107,7 @@ describe('Tree', () => {
       value: 'root',
       hasChildren: true,
       id: 6,
-    }
+    };
 
     const tree: Tree = new Tree(model);
 


### PR DESCRIPTION
Hi @rychkog 

I added a support for Redux loading in the tree.

The way it works is the following:

- The `TreeModel` exposes an optional  boolean field called `hasChildren`. if this property is set to true, the `Tree` will **consider the current node as a `branch`** and allow expanding it.
- When the node is expanded an `LoadNextLevel` event is fired (through the `tree.service` to the `tree.component` and from  there **an event is emitted to the user**.
- The user should handle the event and change the state of the tree (load the next level).
- When the redux pipeline is finished the root `TreeModel` is now containing the children and those children will be viewed in the tree as if a `children` property was provided.

2 Things you should know:

1.  If the user proivided a `TreeModel` with `loadChildren` function and `hasChildren` set to true. **The `loadChildren` will take precedence and no `loadNextLevel` event will be fired.**
2. while firing the event **the  `_childrenLoadingState` will transit to `Loading` state.** which means the event will fire once per node (on the second time the loading state will prevent from additional event to be fired).

One small issue which is still open: when the tree is recreated all the nodes are expanded by default. That means if the user collapsed one branch and then expanded another branch for the first time, the tree will be recreated and all the branches (including the collapsed one) will be expanded.

For now I handled it with a bookepper that remember all the collapsed nodes and re collapsed them.
I wish to have a better solution, for example the `TreeModel` will have an `expanded` property that will tell the initial state of the node.
What do you say?

Thanks a lot,
TMaster.

