### PR TITLE
#123: Distinguishing nodeRemoved and nodeMoved events

### DIFF
--- a/src/tree-internal.component.ts
+++ b/src/tree-internal.component.ts
@@ -175,13 +175,13 @@ export class TreeInternalComponent implements OnInit, OnChanges, OnDestroy, Afte
   }
 
   private moveNodeToThisTreeAndRemoveFromPreviousOne(e: NodeDraggableEvent, tree: Tree): void {
-    this.treeService.fireNodeRemoved(e.captured.tree);
+    e.captured.tree.removeItselfFromParent();
     const addedChild = tree.addChild(e.captured.tree);
     this.treeService.fireNodeMoved(addedChild, e.captured.tree.parent);
   }
 
   private moveNodeToParentTreeAndRemoveFromPreviousOne(e: NodeDraggableEvent, tree: Tree): void {
-    this.treeService.fireNodeRemoved(e.captured.tree);
+    e.captured.tree.removeItselfFromParent();
     const addedSibling = tree.addSibling(e.captured.tree, tree.positionInParent);
     this.treeService.fireNodeMoved(addedSibling, e.captured.tree.parent);
   }


### PR DESCRIPTION
There are some use cases where **nodeRemoved** event firing is undesirable and confusing. 