### PR TITLE
Update styles.css

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -38,7 +38,7 @@
   content: '\25CF';
 }
 .node-menu .node-menu-content .node-menu-item .node-menu-item-icon.new-folder:before {
-  content: '\25B6';
+  content: '\25BA';
 }
 
 .node-menu .node-menu-content .node-menu-item .node-menu-item-icon.rename:before {
@@ -132,7 +132,7 @@ tree-internal .tree .folding.node-collapsed {
 }
 
 tree-internal .tree .folding.node-collapsed:before {
-  content: '\25B6';
+  content: '\25BA';
   color: #757575;
 }
 
@@ -152,7 +152,7 @@ tree-internal .tree .folding.node-empty {
 }
 
 tree-internal .tree .folding.node-empty:before {
-  content: '\25B6';
+  content: '\25BA';
   color: #757575;
 }
 


### PR DESCRIPTION
Updating the unicode character for the collapsed tree node, as the 25BA should be used. This unicode character displays the same symbol in mobile safari as well as on desktop browsers. The prior unicode character was displayed on mobile safari like in the attached picture. 
![Screenshot 2019-03-25 at 10 06 20](https://user-images.githubusercontent.com/15142895/54907411-b6a11c80-4ee5-11e9-8f12-fccbbdd61d78.png)
